### PR TITLE
 Implementation of Number to Words Service with Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/service.cpython-39.pyc
+__pycache__/app.cpython-39.pyc

--- a/bentofile.yaml
+++ b/bentofile.yaml
@@ -1,0 +1,12 @@
+service: "service:NumberToWordsService"
+description: "A Bento service that converts numbers to words"
+labels:
+  owner: jayasudha
+  stage: demo
+include:
+  - "*.py"
+python:
+  packages:
+    - inflect
+    - bentoml==1.3.20
+    - pydantic>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+bentoml
+fastapi
+uvicorn
+inflect

--- a/service.py
+++ b/service.py
@@ -1,0 +1,22 @@
+import bentoml
+import inflect
+
+# Initialize the Inflect engine for number-to-words conversion
+p = inflect.engine()
+
+@bentoml.service(name="number_to_words_service")
+class NumberToWordsService:
+    @bentoml.api
+    def convert_number(self, input_data: dict) -> dict:
+        try:
+            number = input_data.get("number")
+            if number is None:
+                return {"error": "Missing 'number' in input data"}
+            
+            words = p.number_to_words(number)
+            return {
+                "number": number,
+                "words": words
+            }
+        except Exception as e:
+            return {"error": str(e)}


### PR DESCRIPTION
**Title: Implementation of Number to Words Service with Dependencies**

---

### Description

This pull request introduces a new service that converts numbers into their corresponding word form. It utilizes the **Inflect** library for the conversion and **BentoML** for building the API service. The following changes have been made:

#### Key Changes:
- **`NumberToWordsService` Class**: Added a service that exposes an API for converting numbers to words.
- **API Method**: Implemented the `convert_number` method, which takes an input dictionary, processes the number, and returns the word equivalent.
- **Dependencies**: 
  - `inflect`: A Python library for number-to-words conversion.
  - `bentoml`: The framework used to build the service.
  - `fastapi` and `uvicorn`: Required for API serving.

#### Files Changed:
1. **`bentofile.yaml`**: Configured BentoML service and included necessary dependencies.
2. **`requirements.txt`**: Added dependencies for BentoML, FastAPI, Uvicorn, and Inflect.
3. **`service.py`**: The main service file where the number-to-words functionality is implemented.

### How to Run:
1. **Build the BentoML Service**:
   After pulling the changes, build the service using the following command:
   ```bash
   bentoml build
   ```

2. **Serve the Service**:
   To start the service, run:
   ```bash
   bentoml serve service:NumberToWordsService
   ```

   This will start the service, and it will be available for API calls.

### Example:
Once the service is running, you can send a POST request with a JSON body containing a number to be converted to words:

```json
{
  "number": 123
}
```
_Response_:
```json
{
  "number": 123,
  "words": "one hundred and twenty-three"
}
```
